### PR TITLE
Add documentation for resolving JwtAuthGuard dependency errors

### DIFF
--- a/docs/nest-jwt-auth-guard.md
+++ b/docs/nest-jwt-auth-guard.md
@@ -1,0 +1,57 @@
+# Troubleshooting `UnknownDependenciesException` for `JwtAuthGuard`
+
+When running a NestJS application you may see an error similar to the following during boot:
+
+```
+Nest can't resolve dependencies of the JwtAuthGuard (?, ConfigService, PrismaService).
+Please make sure that the argument JwtService at index [0] is available in the UsersModule context.
+```
+
+This error means that the NestJS dependency injection container cannot find a `JwtService` provider when it tries to construct your `JwtAuthGuard`. Typically this happens because the module that defines the guard does not import the Nest `JwtModule` (or another module that exports `JwtService`).
+
+## How to fix it
+
+1. **Import `JwtModule` in the module that declares the guard.**
+
+   ```ts
+   import { JwtModule } from '@nestjs/jwt';
+
+   @Module({
+     imports: [JwtModule.register({
+       secret: process.env.JWT_SECRET,
+       signOptions: { expiresIn: '1h' },
+     })],
+     providers: [JwtAuthGuard],
+     exports: [JwtAuthGuard],
+   })
+   export class UsersModule {}
+   ```
+
+2. **Or re-export `JwtService` from a shared authentication module.**
+
+   If you already configure JWT in an `AuthModule`, export the `JwtModule` (or a custom provider that wraps `JwtService`) and import that module anywhere you need to use the guard.
+
+   ```ts
+   @Module({
+     imports: [JwtModule.register({...})],
+     providers: [AuthService, JwtStrategy],
+     exports: [JwtModule],
+   })
+   export class AuthModule {}
+   ```
+
+   Then, in `UsersModule`:
+
+   ```ts
+   @Module({
+     imports: [AuthModule],
+     providers: [UsersService, JwtAuthGuard],
+   })
+   export class UsersModule {}
+   ```
+
+3. **Ensure the guard's constructor only requests providers that are available.**
+
+   If your guard injects additional dependencies (for example, `PrismaService`), make sure those services are provided within the same module or imported modules.
+
+After making these changes, restart the application. Nest should now be able to instantiate `JwtAuthGuard` without throwing `UnknownDependenciesException`.


### PR DESCRIPTION
## Summary
- add troubleshooting guide covering NestJS UnknownDependenciesException for JwtAuthGuard
- document fixes for missing JwtService providers via JwtModule imports or shared modules

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d9cfc35ebc832897b3e31b98ff6a9a