### PR TITLE
Add backend example fixing NestJS JwtAuthGuard dependency

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,11 @@
+# Backend Example for JwtAuthGuard Fix
+
+This minimal NestJS backend demonstrates how to correctly wire the `JwtAuthGuard` so that Nest can resolve the `JwtService` dependency.
+
+## Key points
+
+- `AuthModule` registers and exports `JwtModule` using `registerAsync`, allowing other modules to inject `JwtService`.
+- `UsersModule` imports `AuthModule` and provides `JwtAuthGuard` alongside any services/controllers that depend on it.
+- `UsersController` applies the guard with `@UseGuards(JwtAuthGuard)`.
+
+By following this structure, the dependency injection container will always have access to `JwtService` whenever it instantiates `JwtAuthGuard`, resolving the `UnknownDependenciesException`.

--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "spacex-launches-backend",
+  "version": "1.0.0",
+  "description": "Minimal NestJS backend to demonstrate proper JwtAuthGuard wiring.",
+  "private": true,
+  "scripts": {
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "build": "nest build"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/config": "^3.1.1",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/jwt": "^10.0.3",
+    "@nestjs/passport": "^10.0.0",
+    "passport": "^0.7.0",
+    "passport-jwt": "^4.0.1",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.1.17",
+    "@nestjs/schematics": "^10.0.0",
+    "@nestjs/testing": "^10.0.0",
+    "typescript": "^5.1.6"
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { UsersModule } from './users/users.module';
+
+@Module({
+  imports: [ConfigModule.forRoot({ isGlobal: true }), UsersModule],
+})
+export class AppModule {}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { PassportModule } from '@nestjs/passport';
+import { JwtStrategy } from './jwt.strategy';
+
+@Module({
+  imports: [
+    ConfigModule,
+    PassportModule,
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: async (config: ConfigService) => ({
+        secret: config.get<string>('JWT_SECRET', 'development-secret'),
+        signOptions: {
+          expiresIn: config.get<string | number>('JWT_EXPIRES_IN', '60m'),
+        },
+      }),
+    }),
+  ],
+  providers: [JwtStrategy],
+  exports: [JwtModule, PassportModule],
+})
+export class AuthModule {}

--- a/backend/src/auth/jwt-auth.guard.ts
+++ b/backend/src/auth/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(config: ConfigService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: config.get<string>('JWT_SECRET', 'development-secret'),
+    });
+  }
+
+  async validate(payload: any) {
+    return { userId: payload.sub, email: payload.email };
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,9 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+
+bootstrap();

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { UsersService } from './users.service';
+
+@Controller('users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get(':id')
+  @UseGuards(JwtAuthGuard)
+  async getUser(@Param('id') id: string) {
+    return this.usersService.findUserById(id);
+  }
+}

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { UsersService } from './users.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { UsersController } from './users.controller';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [UsersController],
+  providers: [UsersService, JwtAuthGuard],
+  exports: [UsersService, JwtAuthGuard],
+})
+export class UsersModule {}

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class UsersService {
+  async findUserById(id: string) {
+    return { id };
+  }
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2019",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/docs/nest-jwt-auth-guard.md
+++ b/docs/nest-jwt-auth-guard.md
@@ -55,3 +55,7 @@ This error means that the NestJS dependency injection container cannot find a `J
    If your guard injects additional dependencies (for example, `PrismaService`), make sure those services are provided within the same module or imported modules.
 
 After making these changes, restart the application. Nest should now be able to instantiate `JwtAuthGuard` without throwing `UnknownDependenciesException`.
+
+## Example implementation in this repository
+
+See [`backend/`](../backend) for a minimal NestJS setup that resolves the guard correctly. The `AuthModule` exports the configured `JwtModule`, and `UsersModule` imports it before providing `JwtAuthGuard`. This ensures the guard's constructor receives `JwtService` without triggering `UnknownDependenciesException`.


### PR DESCRIPTION
## Summary
- add a minimal NestJS backend that wires JwtAuthGuard through an AuthModule exporting JwtModule
- include example users module/controller demonstrating guard usage without UnknownDependenciesException
- update existing documentation to point to the working example

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9d27f90a48328aae0877e399253c7